### PR TITLE
feat: filtra dados do dashboard por empresa do usuario autenticado

### DIFF
--- a/backend/src/main/java/br/com/recycle/backend/repository/EstoqueRepository.java
+++ b/backend/src/main/java/br/com/recycle/backend/repository/EstoqueRepository.java
@@ -1,5 +1,6 @@
 package br.com.recycle.backend.repository;
 
+import br.com.recycle.backend.model.Empresa;
 import br.com.recycle.backend.model.Estoque;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,5 +11,6 @@ import java.util.Optional;
 @Repository
 public interface EstoqueRepository extends JpaRepository<Estoque, Long> {
     List<Estoque> findAllByMaterial_UsuarioId(Long usuarioId);
+    List<Estoque> findAllByMaterial_Usuario_Empresa(Empresa empresa);
     Optional<Estoque> findByMaterialIdAndMaterial_UsuarioId(Long materialId, Long usuarioId);
 }

--- a/backend/src/main/java/br/com/recycle/backend/service/EstoqueService.java
+++ b/backend/src/main/java/br/com/recycle/backend/service/EstoqueService.java
@@ -9,6 +9,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import br.com.recycle.backend.dto.EstoqueResponseDTO;
+import br.com.recycle.backend.model.Empresa;
 import br.com.recycle.backend.model.Estoque;
 import br.com.recycle.backend.repository.EstoqueRepository;
 
@@ -16,11 +17,14 @@ import br.com.recycle.backend.repository.EstoqueRepository;
 public class EstoqueService {
 
     private final EstoqueRepository estoqueRepository;
+    private final FuncionarioService funcionarioService;
 
     @Autowired
-    public EstoqueService(EstoqueRepository estoqueRepository) {
+    public EstoqueService(EstoqueRepository estoqueRepository, FuncionarioService funcionarioService) {
         this.estoqueRepository = estoqueRepository;
+        this.funcionarioService = funcionarioService;
     }
+
     @PreAuthorize("hasAnyRole('GERENTE','OPERADOR')")
     public EstoqueResponseDTO buscarPorId(Long id, Long usuarioId) {
 
@@ -41,7 +45,8 @@ public class EstoqueService {
     }
     @PreAuthorize("hasAnyRole('GERENTE','OPERADOR')")
     public DashboardDTO gerarResumoDashboard(Long usuarioId) {
-        List<Estoque> estoques = estoqueRepository.findAllByMaterial_UsuarioId(usuarioId);
+        Empresa empresa = funcionarioService.getEmpresaUsuario(usuarioId);
+        List<Estoque> estoques = estoqueRepository.findAllByMaterial_Usuario_Empresa(empresa);
 
         Float valorTotal = estoques.stream()
                 .map(Estoque::getValorTotal)

--- a/backend/src/main/java/br/com/recycle/backend/service/FuncionarioService.java
+++ b/backend/src/main/java/br/com/recycle/backend/service/FuncionarioService.java
@@ -25,12 +25,15 @@ public class FuncionarioService {
         this.passwordEncoder = passwordEncoder;
     }
 
+    public Empresa getEmpresaUsuario(Long usuarioId) {
+        return usuarioRepository.findById(usuarioId)
+            .map(usuario -> usuario.getEmpresa())
+            .orElseThrow(() -> new RuntimeException("Usuário não encontrado"));
+    }
+
     @Transactional
     public Usuario criarFuncionario(Long gerenteId, FuncionarioDTO dto) {
-        Usuario gerente = usuarioRepository.findById(gerenteId)
-                .orElseThrow(() -> new RuntimeException("Gerente não encontrado"));
-
-        Empresa empresa = gerente.getEmpresa();
+        Empresa empresa = getEmpresaUsuario(gerenteId);
 
         if (usuarioRepository.existsByEmail(dto.getEmail())) {
             throw new RuntimeException("Email já cadastrado");


### PR DESCRIPTION
Close #129

Antes os dados de resumo do dashboard não estavam sendo carregados corretamente por estarem usando o padrão antigo de:
- 1 usuário - 1 estoque

Como mudamos a regra de negócio para **1 estoque - N usuários**, usar o Id de usuário apenas não funciona.
Essa PR troca o parâmetro de busca de:
-  ID do usuário (antes) -> Empresa do Usuário (Agora).